### PR TITLE
Add Windows installer script bundling Tesseract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+*.egg-info/
+.venv/
+venv/
+.env
+.dist/
+build/
+dist/
+.idea/
+.vscode/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,86 @@
-# aim
+# AIM
+
+Ce dépôt fournit un utilitaire OCR Python ainsi qu'un script d'installation Windows
+capable d'installer automatiquement Tesseract OCR. L'objectif est de proposer un
+installateur unique afin de ne plus avoir à installer Tesseract manuellement.
+
+## Aperçu
+
+- **CLI Python** : la commande `aim-cli` (ou `python -m aim`) permet de lancer un OCR
+  sur une image en s'appuyant sur `pytesseract` et Tesseract.
+- **Installateur Windows** : `installers/windows/install.ps1` télécharge et installe
+  automatiquement Tesseract, configure les variables d'environnement et installe ce
+  projet dans un environnement virtuel dédié.
+
+## Installation sur Windows
+
+1. Installez Python 3.9 ou supérieur sur la machine cible (activer l'option « Ajouter
+   Python au PATH » est recommandé).
+2. Téléchargez le contenu de ce dépôt ou incluez-le dans le package de distribution
+   de votre application.
+3. Ouvrez un terminal PowerShell **en tant qu'administrateur** (Tesseract s'installe
+   sous `Program Files`).
+4. Exécutez l'installateur :
+
+   ```powershell
+   Set-ExecutionPolicy -Scope Process Bypass -Force
+   ./installers/windows/install.ps1
+   ```
+
+   Le script :
+
+   - Télécharge la dernière version 64 bits de Tesseract fournie par
+     [UB Mannheim](https://github.com/UB-Mannheim/tesseract/wiki) ;
+   - Installe silencieusement Tesseract si nécessaire et ajoute son répertoire au PATH ;
+   - Crée (ou met à jour) un environnement virtuel Python dans `%LOCALAPPDATA%\aim` ;
+   - Installe ce package Python et ses dépendances (`pytesseract`, `Pillow`, ...)
+     dans l'environnement créé ;
+   - Génère des scripts de lancement (`aim.cmd` / `aim.ps1`) pointant vers l'environnement.
+
+### Options de l'installateur
+
+Le script accepte quelques paramètres utiles :
+
+```powershell
+./installers/windows/install.ps1 -InstallRoot "C:\\MonAppli" -ForceReinstall
+```
+
+- `-InstallRoot` : répertoire cible (par défaut `%LOCALAPPDATA%\aim`).
+- `-TesseractInstallerUrl` : URL personnalisée vers un installateur Tesseract.
+- `-ForceReinstall` : force la recréation de l'environnement virtuel et la
+  réinstallation de Tesseract même s'ils existent déjà.
+
+## Utilisation de la CLI
+
+Une fois l'installation terminée :
+
+```powershell
+# Affiche la version de Tesseract détectée
+C:\Users\<Vous>\AppData\Local\aim\aim.cmd --show-version
+
+# Lance un OCR sur une image
+C:\Users\<Vous>\AppData\Local\aim\aim.cmd "C:\\chemin\\vers\\mon_image.png" --lang fra
+```
+
+Vous pouvez également utiliser `python -m aim` depuis l'environnement virtuel installé.
+
+## Désinstallation
+
+1. Supprimez le dossier d'installation (par défaut `%LOCALAPPDATA%\aim`).
+2. Facultatif : supprimez la clé d'environnement utilisateur `TESSDATA_PREFIX` et
+   retirez le chemin `C:\Program Files\Tesseract-OCR` de votre PATH utilisateur si
+   vous ne souhaitez plus Tesseract sur la machine.
+
+## Développement
+
+Pour contribuer au projet :
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # sous Windows : .venv\\Scripts\\activate
+pip install --upgrade pip
+pip install -e .
+```
+
+Les sources principales se trouvent dans `src/aim`. La CLI est implémentée dans
+`src/aim/cli.py` et le script d'installation se trouve dans `installers/windows`.

--- a/installers/windows/README.md
+++ b/installers/windows/README.md
@@ -1,0 +1,49 @@
+# Installateur Windows
+
+Le script `install.ps1` automatise l'installation de Tesseract et de l'application
+Python fournie dans ce dépôt. Il s'agit d'un installateur « sans assistance » qui
+peut être exécuté directement sur une machine cliente ou intégré dans un installeur
+NSIS/Inno Setup existant.
+
+## Pré-requis
+
+- Windows 10/11
+- PowerShell 5.1 ou 7+
+- Python 3.9 ou supérieur installé localement
+- Accès Internet pour télécharger l'installateur Tesseract et les dépendances Python
+
+## Utilisation rapide
+
+```powershell
+Set-ExecutionPolicy -Scope Process Bypass -Force
+./install.ps1
+```
+
+Le script s'occupe de :
+
+1. Télécharger l'installateur Tesseract 64 bits (`tesseract-ocr-w64-setup-5.3.3.20231005.exe`).
+2. Lancer l'installation silencieuse de Tesseract (si nécessaire) et ajouter le chemin
+   `Tesseract-OCR` au PATH utilisateur.
+3. Créer un environnement virtuel Python dédié et y installer ce package (`pip install .`).
+4. Générer des scripts de lancement (`aim.cmd`, `aim.ps1`) qui invoquent l'application
+   depuis l'environnement virtuel.
+
+## Paramètres disponibles
+
+- `InstallRoot` : dossier cible de l'installation (`%LOCALAPPDATA%\aim` par défaut).
+- `TesseractInstallerUrl` : URL vers un installateur Tesseract alternatif.
+- `ForceReinstall` : force la réinstallation complète même si Tesseract et l'environnement
+  virtuel existent déjà.
+
+Exemple :
+
+```powershell
+./install.ps1 -InstallRoot "C:\\Program Files\\AIM" -ForceReinstall
+```
+
+## Intégration dans un installeur graphique
+
+Ce script peut être invoqué depuis un installeur NSIS/Inno Setup en arrière-plan pour
+installer silencieusement Tesseract avant de copier votre application. Veillez à exécuter
+le script avec les droits administrateur pour permettre l'installation de Tesseract dans
+`Program Files`.

--- a/installers/windows/install.ps1
+++ b/installers/windows/install.ps1
@@ -1,0 +1,238 @@
+[CmdletBinding()]
+param(
+    [string]$InstallRoot = (Join-Path $env:LOCALAPPDATA "aim"),
+    [string]$TesseractInstallerUrl = "https://github.com/UB-Mannheim/tesseract/releases/download/v5.3.3.20231005/tesseract-ocr-w64-setup-5.3.3.20231005.exe",
+    [switch]$ForceReinstall
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Write-Section {
+    param([string]$Message)
+    Write-Host "`n== $Message ==" -ForegroundColor Cyan
+}
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host "  -> $Message" -ForegroundColor Green
+}
+
+function Resolve-ProjectRoot {
+    $scriptDir = Split-Path -Path $MyInvocation.MyCommand.Definition -Parent
+    return (Resolve-Path (Join-Path $scriptDir "..\..")).Path
+}
+
+function Get-TesseractPath {
+    $candidates = @(
+        "$env:ProgramFiles\\Tesseract-OCR\\tesseract.exe",
+        "$env:ProgramFiles(x86)\\Tesseract-OCR\\tesseract.exe",
+        "$env:LOCALAPPDATA\\Programs\\Tesseract-OCR\\tesseract.exe"
+    )
+
+    $command = Get-Command -Name tesseract.exe -ErrorAction SilentlyContinue
+    if ($null -ne $command -and $command.Source) {
+        $candidates += $command.Source
+    }
+
+    foreach ($candidate in $candidates) {
+        if ([string]::IsNullOrWhiteSpace($candidate)) { continue }
+        if (Test-Path -LiteralPath $candidate) {
+            return (Resolve-Path -LiteralPath $candidate).Path
+        }
+    }
+
+    return $null
+}
+
+function Download-TesseractInstaller {
+    param([string]$Url)
+
+    $target = Join-Path ([IO.Path]::GetTempPath()) "tesseract-installer-$([Guid]::NewGuid()).exe"
+    Write-Step "Téléchargement de Tesseract depuis $Url"
+    Invoke-WebRequest -Uri $Url -OutFile $target -UseBasicParsing
+    return $target
+}
+
+function Install-Tesseract {
+    param(
+        [string]$Url,
+        [switch]$Force
+    )
+
+    if (-not $Force) {
+        $existing = Get-TesseractPath
+        if ($null -ne $existing) {
+            Write-Step "Tesseract déjà détecté : $existing"
+            return $existing
+        }
+    }
+
+    $installer = Download-TesseractInstaller -Url $Url
+    try {
+        Write-Step "Installation silencieuse de Tesseract..."
+        $process = Start-Process -FilePath $installer -ArgumentList '/SILENT', '/ALLUSERS' -PassThru -Wait -WindowStyle Hidden
+        if ($process.ExitCode -ne 0) {
+            throw "L'installation de Tesseract a échoué avec le code $($process.ExitCode)."
+        }
+    }
+    finally {
+        Remove-Item -LiteralPath $installer -ErrorAction SilentlyContinue
+    }
+
+    $path = Get-TesseractPath
+    if (-not $path) {
+        throw "Impossible de localiser Tesseract après l'installation."
+    }
+
+    return $path
+}
+
+function Update-UserPath {
+    param([string]$Directory)
+
+    $resolved = (Resolve-Path -LiteralPath $Directory).Path
+    $current = [Environment]::GetEnvironmentVariable('Path', 'User')
+    $entries = @()
+    if ($current) {
+        $entries = $current -split ';' | Where-Object { $_ }
+    }
+
+    foreach ($entry in $entries) {
+        if ([string]::Equals($entry.TrimEnd('\'), $resolved.TrimEnd('\'), [StringComparison]::OrdinalIgnoreCase)) {
+            return
+        }
+    }
+
+    $newPath = if ($current) { "$current;$resolved" } else { $resolved }
+    [Environment]::SetEnvironmentVariable('Path', $newPath, 'User')
+    $env:PATH = "$resolved;" + $env:PATH
+}
+
+function Configure-TesseractEnvironment {
+    param([string]$TesseractExecutable)
+
+    $tesseractDir = Split-Path -Path $TesseractExecutable -Parent
+    Update-UserPath -Directory $tesseractDir
+    [Environment]::SetEnvironmentVariable('TESSDATA_PREFIX', $tesseractDir, 'User')
+    $env:TESSDATA_PREFIX = $tesseractDir
+    Write-Step "Variables d'environnement mises à jour pour Tesseract ($tesseractDir)."
+}
+
+function Get-PythonCommand {
+    $python = Get-Command -Name python.exe -ErrorAction SilentlyContinue
+    if ($python) {
+        return @{ Path = $python.Source; Args = @() }
+    }
+
+    $pyLauncher = Get-Command -Name py.exe -ErrorAction SilentlyContinue
+    if ($pyLauncher) {
+        return @{ Path = $pyLauncher.Source; Args = @('-3') }
+    }
+
+    throw "Python 3 n'a pas été détecté. Installez Python 3.9+ avant de lancer ce script."
+}
+
+function Invoke-ExternalCommand {
+    param(
+        [hashtable]$Command,
+        [string[]]$Arguments
+    )
+
+    & $Command.Path @($Command.Args + $Arguments)
+    if ($LASTEXITCODE -ne 0) {
+        $argumentList = ($Arguments -join ' ')
+        throw "La commande '$($Command.Path) $argumentList' a échoué avec le code $LASTEXITCODE."
+    }
+}
+
+function Ensure-VirtualEnvironment {
+    param(
+        [hashtable]$PythonCommand,
+        [string]$VenvPath,
+        [switch]$Force
+    )
+
+    if ($Force -and (Test-Path -LiteralPath $VenvPath)) {
+        Write-Step "Suppression de l'environnement virtuel existant ($VenvPath)."
+        Remove-Item -LiteralPath $VenvPath -Recurse -Force
+    }
+
+    if (-not (Test-Path -LiteralPath $VenvPath)) {
+        Write-Step "Création de l'environnement virtuel ($VenvPath)."
+        Invoke-ExternalCommand -Command $PythonCommand -Arguments @('-m', 'venv', $VenvPath)
+    }
+    else {
+        Write-Step "Environnement virtuel existant détecté ($VenvPath)."
+    }
+
+    $venvPython = Join-Path $VenvPath 'Scripts\python.exe'
+    if (-not (Test-Path -LiteralPath $venvPython)) {
+        throw "L'environnement virtuel semble corrompu : python.exe est introuvable."
+    }
+
+    return @{ Path = $venvPython; Args = @() }
+}
+
+function Install-PythonProject {
+    param(
+        [hashtable]$PythonCommand,
+        [string]$ProjectRoot,
+        [switch]$Force
+    )
+
+    Write-Step "Mise à jour de pip et des outils de build."
+    Invoke-ExternalCommand -Command $PythonCommand -Arguments @('-m', 'pip', 'install', '--upgrade', 'pip', 'setuptools', 'wheel')
+
+    if ($Force) {
+        Write-Step "Réinstallation forcée du package aim."
+        Invoke-ExternalCommand -Command $PythonCommand -Arguments @('-m', 'pip', 'install', '--upgrade', '--force-reinstall', $ProjectRoot)
+    }
+    else {
+        Invoke-ExternalCommand -Command $PythonCommand -Arguments @('-m', 'pip', 'install', '--upgrade', $ProjectRoot)
+    }
+}
+
+function Ensure-Launchers {
+    param(
+        [string]$InstallPath,
+        [string]$VenvPath
+    )
+
+    $cmdPath = Join-Path $InstallPath 'aim.cmd'
+    $cmdContent = "@echo off`r`n\"%~dp0venv\\Scripts\\python.exe\" -m aim %*`r`n"
+    Set-Content -Path $cmdPath -Value $cmdContent -Encoding ASCII
+
+    $ps1Path = Join-Path $InstallPath 'aim.ps1'
+    $ps1Content = "& \"$VenvPath\\Scripts\\python.exe\" -m aim @args"
+    Set-Content -Path $ps1Path -Value $ps1Content -Encoding UTF8
+
+    Write-Step "Scripts de lancement générés :`n  - $cmdPath`n  - $ps1Path"
+}
+
+function Ensure-InstallRoot {
+    param([string]$Path)
+
+    $directory = New-Item -ItemType Directory -Path $Path -Force
+    return (Resolve-Path -LiteralPath $directory.FullName).Path
+}
+
+$projectRoot = Resolve-ProjectRoot
+$installPath = Ensure-InstallRoot -Path $InstallRoot
+
+Write-Section "Installation de AIM"
+Write-Step "Dossier projet : $projectRoot"
+Write-Step "Dossier d'installation : $installPath"
+
+$tesseractExe = Install-Tesseract -Url $TesseractInstallerUrl -Force:$ForceReinstall
+Configure-TesseractEnvironment -TesseractExecutable $tesseractExe
+
+$python = Get-PythonCommand
+$venvCommand = Ensure-VirtualEnvironment -PythonCommand $python -VenvPath (Join-Path $installPath 'venv') -Force:$ForceReinstall
+Install-PythonProject -PythonCommand $venvCommand -ProjectRoot $projectRoot -Force:$ForceReinstall
+Ensure-Launchers -InstallPath $installPath -VenvPath (Join-Path $installPath 'venv')
+
+Write-Section "Installation terminée"
+Write-Host "Tesseract installé à : $tesseractExe"
+Write-Host "AIM est disponible via : $(Join-Path $installPath 'aim.cmd')"
+Write-Host "Vous devrez peut-être rouvrir votre terminal pour prendre en compte les nouvelles variables d'environnement."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "aim"
+version = "0.1.0"
+description = "OCR helper that bundles Tesseract installation helpers for Windows"
+readme = "README.md"
+authors = [
+  { name = "AIM Developers" }
+]
+license = { text = "MIT" }
+requires-python = ">=3.9"
+dependencies = [
+  "pytesseract>=0.3.10",
+  "Pillow>=10.0.0"
+]
+
+[project.scripts]
+aim-cli = "aim.cli:main"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/aim/__init__.py
+++ b/src/aim/__init__.py
@@ -1,0 +1,12 @@
+"""AIM OCR helper package."""
+
+from __future__ import annotations
+
+from importlib import metadata
+
+try:
+    __version__ = metadata.version("aim")
+except metadata.PackageNotFoundError:  # pragma: no cover - during local execution only
+    __version__ = "0.1.0"
+
+__all__ = ["__version__"]

--- a/src/aim/__main__.py
+++ b/src/aim/__main__.py
@@ -1,0 +1,8 @@
+"""Entry point to run the CLI with `python -m aim`."""
+
+from __future__ import annotations
+
+from .cli import main
+
+if __name__ == "__main__":  # pragma: no cover - module entry point
+    main()

--- a/src/aim/cli.py
+++ b/src/aim/cli.py
@@ -1,0 +1,137 @@
+"""Command line interface to run OCR with Tesseract."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+
+
+class TesseractNotAvailableError(RuntimeError):
+    """Raised when Tesseract cannot be located on the system."""
+
+
+def resolve_tesseract(executable: str | None = None) -> Path:
+    """Return the path to the Tesseract executable.
+
+    Parameters
+    ----------
+    executable:
+        Optional explicit path provided by the user.
+
+    Raises
+    ------
+    TesseractNotAvailableError
+        If no executable can be found.
+    """
+
+    if executable:
+        explicit = Path(executable).expanduser()
+        if explicit.is_file():
+            return explicit
+        raise TesseractNotAvailableError(
+            f"Le binaire Tesseract spécifié '{explicit}' est introuvable."
+        )
+
+    auto_detected = shutil.which("tesseract")
+    if auto_detected:
+        return Path(auto_detected)
+
+    raise TesseractNotAvailableError(
+        "Tesseract n'est pas disponible. Exécutez le script install.ps1 pour l'installer."
+    )
+
+
+def get_tesseract_version(executable: str | None = None) -> str:
+    """Return the version string reported by Tesseract."""
+
+    tesseract_path = resolve_tesseract(executable)
+    completed = subprocess.run(
+        [str(tesseract_path), "--version"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def run_ocr(image_path: Path, *, lang: str = "eng", executable: str | None = None) -> str:
+    """Extract text from an image using pytesseract."""
+
+    from PIL import Image
+    import pytesseract
+
+    tesseract_path = resolve_tesseract(executable)
+    pytesseract.pytesseract.tesseract_cmd = str(tesseract_path)
+
+    with Image.open(image_path) as img:
+        text = pytesseract.image_to_string(img, lang=lang)
+    return text.strip()
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="aim-cli",
+        description="Utilitaire OCR utilisant Tesseract et pytesseract.",
+    )
+    parser.add_argument(
+        "image",
+        nargs="?",
+        help="Fichier image à analyser (PNG, JPEG, etc.).",
+    )
+    parser.add_argument(
+        "--lang",
+        default="eng",
+        help="Code langue Tesseract à utiliser (defaut: eng).",
+    )
+    parser.add_argument(
+        "--tesseract",
+        help="Chemin personnalisé vers l'exécutable Tesseract.",
+    )
+    parser.add_argument(
+        "--show-version",
+        action="store_true",
+        help="Affiche la version de Tesseract détectée et quitte.",
+    )
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.show_version:
+        try:
+            print(get_tesseract_version(args.tesseract))
+        except TesseractNotAvailableError as exc:
+            parser.error(str(exc))
+        except subprocess.CalledProcessError as exc:  # pragma: no cover - depends on system
+            parser.error(f"Impossible d'interroger Tesseract: {exc}")
+        return
+
+    if not args.image:
+        parser.error(
+            "Vous devez fournir un fichier image ou utiliser l'option --show-version."
+        )
+
+    image_path = Path(args.image)
+    if not image_path.exists():
+        parser.error(f"Le fichier '{image_path}' est introuvable.")
+
+    try:
+        text = run_ocr(image_path, lang=args.lang, executable=args.tesseract)
+    except TesseractNotAvailableError as exc:
+        parser.error(str(exc))
+    except subprocess.CalledProcessError as exc:  # pragma: no cover - depends on system
+        parser.error(f"L'exécution de Tesseract a échoué: {exc}")
+    except Exception as exc:  # pragma: no cover - unexpected runtime issues
+        parser.error(f"Une erreur inattendue est survenue: {exc}")
+    else:
+        sys.stdout.write(text + "\n")
+
+
+if __name__ == "__main__":  # pragma: no cover - module entry point
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,45 @@
+"""Tests pour le module aim.cli."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / 'src'))
+
+from aim import cli
+
+
+class ResolveTesseractTests(unittest.TestCase):
+    def test_explicit_path_missing(self) -> None:
+        with self.assertRaises(cli.TesseractNotAvailableError):
+            cli.resolve_tesseract("C:/invalid/tesseract.exe")
+
+    @mock.patch("shutil.which", return_value=None)
+    def test_auto_detection_missing(self, which: mock.Mock) -> None:
+        with self.assertRaises(cli.TesseractNotAvailableError):
+            cli.resolve_tesseract()
+        which.assert_called_once_with("tesseract")
+
+
+class GetTesseractVersionTests(unittest.TestCase):
+    @mock.patch("aim.cli.subprocess.run")
+    @mock.patch("aim.cli.resolve_tesseract")
+    def test_get_tesseract_version(self, resolve: mock.Mock, run: mock.Mock) -> None:
+        resolve.return_value = Path("C:/Program Files/Tesseract-OCR/tesseract.exe")
+        run.return_value = mock.Mock(stdout="tesseract 5.0.0", returncode=0)
+
+        version = cli.get_tesseract_version()
+
+        self.assertEqual(version, "tesseract 5.0.0")
+        run.assert_called_once()
+        args, kwargs = run.call_args
+        self.assertIn("--version", args[0])
+        self.assertTrue(kwargs["check"])  # type: ignore[index]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a PowerShell-based Windows installer that downloads Tesseract, configures PATH/TESSDATA, creates a venv, and installs the project package
- define the Python package/CLI entry point for running OCR with Tesseract and document the workflow in the README files
- add basic unit tests covering the CLI utilities to verify detection logic

## Testing
- python -m unittest discover -s tests -p 'test*.py'
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cbc2ca82cc832d8c45659d7a0400c4