### PR TITLE
Add Rapid Shot heat overlay application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+*.pyo
+build/
+dist/
+*.spec
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,100 @@
-# aim
+# Rapid Shot Heat Overlay
+
+Outil autonome destiné à suivre en temps réel la Heat du sort **Rapid Shot** dans *Path of Exile 2*. L'application s'appuie exclusivement sur la capture d'écran, le template matching et l'OCR pour respecter les règles du jeu.
+
+## Fonctionnalités principales
+
+- **Overlay transparent & click-through** : jauge circulaire toujours visible mais qui laisse passer les clics.
+- **Vision par ordinateur** : localisation multi-échelle du buff Rapid Shot et lecture fiable du compteur de Heat via Tesseract.
+- **Modes d'affichage** : jauge centrée ou attachée au curseur avec offset configurable.
+- **Personnalisation complète** : taille, largeur d'anneau, gap, couleurs (thèmes), ticks fixes, halo visuel et affichage numérique optionnel.
+- **Assistant de calibration** : sélection guidée de l'icône, de la barre de buffs et de la zone OCR. Relance possible via raccourcis (Ctrl+K/I/B/O).
+- **Sauvegarde automatique** : les paramètres sont stockés dans `config.json` (chemins de template, zone de capture, offsets OCR, etc.).
+- **Mode simulation** : un fournisseur interne permet de tester l'interface sans lancer le jeu.
+
+## Installation
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+## Lancement rapide
+
+```bash
+heat-overlay --mode center --debug
+```
+
+Par défaut le fournisseur de données est `cv` (vision). Pour tester l'overlay sans dépendances externes, utilisez :
+
+```bash
+heat-overlay --provider sim --mode cursor --debug
+```
+
+## Options CLI
+
+| Option | Description |
+| --- | --- |
+| `--mode {center,cursor}` | Choisit le mode d'affichage de la jauge. |
+| `--size <int>` | Diamètre de la jauge en pixels. |
+| `--ring <int>` | Largeur de l'anneau. |
+| `--gap <float>` | Angle libre en degrés. |
+| `--threshold <int>` | Valeur déclenchant le halo rouge. |
+| `--max <int>` | Valeur maximale de la jauge. |
+| `--ticks a,b,c` | Position des ticks fixes. |
+| `--cursor-offset x,y` | Décalage appliqué en mode curseur. |
+| `--debug` | Affiche la valeur numérique au centre. |
+| `--theme {default,dark,neo}` | Choisit un thème prédéfini. |
+| `--template PATH` | Spécifie un template d'icône existant. |
+| `--buffbar x,y,w,h` | Définit la région de capture de la barre de buffs. |
+| `--ocrp ox,oy,w,h` | Définit la zone OCR relative à l'icône. |
+| `--tesseract PATH` | Chemin vers `tesseract.exe` portable. |
+| `--provider {cv,sim}` | Sélectionne le fournisseur de Heat. |
+| `--config PATH` | Fichier de configuration personnalisé. |
+| `--log-level` | Niveau de log (`INFO`, `DEBUG`, ...). |
+
+## Calibration
+
+Au premier lancement l'assistant n'est pas obligatoire : utilisez `Ctrl+K` pour afficher le wizard plein écran.
+
+1. **Icône** : capture de l'icône Rapid Shot ⇒ sauvegardée dans `assets/buff_template_captured.png`.
+2. **Barre de buffs** : délimite la zone de recherche pour accélérer le matching.
+3. **Zone OCR** : définit une zone relative à l'icône pour extraire le compteur numérique.
+
+Les raccourcis permettent de relancer individuellement chaque étape :
+
+- `Ctrl+I` : recapture l'icône.
+- `Ctrl+B` : redéfinit la bande des buffs.
+- `Ctrl+O` : recalcule la zone OCR.
+
+Toutes les informations sont écrites dans `config.json` sous la racine du projet (ou le chemin défini via `--config`).
+
+## Fournisseur de Heat
+
+- **cv** : utilise `dxcam` pour capturer l'écran DirectX (Windows), OpenCV pour le template matching multi-échelle et Tesseract pour l'OCR. C'est le mode recommandé en jeu.
+- **sim** : fournisseur sinusoïdal utile pour valider l'UI ou enregistrer des démonstrations.
+
+## Packaging en EXE
+
+1. Téléchargez la version portable de Tesseract et placez-la dans un dossier `tesseract/` à côté de l'exécutable.
+2. Utilisez PyInstaller :
+
+   ```bash
+   pyinstaller --name rapid-shot-overlay --noconsole --onefile \
+     --add-data "assets/*;assets" \
+     --collect-submodules heat_overlay \
+     -p src heat_overlay/app.py
+   ```
+
+3. Copiez le dossier portable de Tesseract et `config.json` à côté du binaire généré.
+
+## Dépannage
+
+- Activez les logs détaillés via `--log-level DEBUG` pour surveiller le matching et l'OCR.
+- Vérifiez que le template Rapid Shot est net et que la zone OCR couvre strictement les chiffres.
+- En cas de changement de résolution ou de scaling Windows, relancez le wizard (Ctrl+K) pour recalculer les offsets relatifs.
+
+## Licence
+
+Projet fourni tel quel, usage personnel recommandé.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[project]
+name = "heat-overlay"
+version = "0.1.0"
+description = "Rapid Shot heat overlay for Path of Exile 2"
+authors = [{name = "AIM"}]
+requires-python = ">=3.9"
+dependencies = [
+  "PySide6>=6.6",
+  "opencv-python>=4.8",
+  "dxcam>=0.0.4",
+  "pytesseract>=0.3.10",
+  "numpy>=1.24",
+]
+
+[project.scripts]
+heat-overlay = "heat_overlay.app:main"
+
+[build-system]
+requires = ["setuptools>=63", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pyinstaller]
+# Placeholder for PyInstaller configuration guidance.

--- a/src/heat_overlay/__init__.py
+++ b/src/heat_overlay/__init__.py
@@ -1,0 +1,6 @@
+"""Heat overlay application package."""
+
+from .config import AppConfig, GaugeTheme
+from .app import main
+
+__all__ = ["AppConfig", "GaugeTheme", "main"]

--- a/src/heat_overlay/app.py
+++ b/src/heat_overlay/app.py
@@ -1,0 +1,240 @@
+"""Application entry point and CLI handling."""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+from typing import Optional
+
+from PySide6 import QtCore, QtGui, QtWidgets
+
+from .calibration import CalibrationWizard
+from .config import AppConfig, DEFAULT_CONFIG_PATH, GaugeTheme
+from .overlay import OverlayWindow
+from .providers import HeatProvider, SimulatedHeatProvider, VisionHeatProvider
+
+LOGGER = logging.getLogger(__name__)
+
+THEMES = {
+    "default": GaugeTheme(),
+    "dark": GaugeTheme(
+        start_color="#ffe082",
+        end_color="#ff6d00",
+        tick_color="#f0f0f0",
+        halo_color="#ff174488",
+        background_color="#ffffff22",
+        text_color="#f0f0f0ff",
+    ),
+    "neo": GaugeTheme(
+        start_color="#00e5ff",
+        end_color="#00bfa5",
+        tick_color="#e0f7fa",
+        halo_color="#00e5ff55",
+        background_color="#001f2a55",
+        text_color="#ffffff",
+    ),
+}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Rapid Shot Heat overlay")
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG_PATH, help="Chemin du fichier config")
+    parser.add_argument("--mode", choices=["center", "cursor"], help="Mode d'affichage de la jauge")
+    parser.add_argument("--size", type=int, help="Diamètre de la jauge")
+    parser.add_argument("--ring", type=int, help="Largeur de l'anneau")
+    parser.add_argument("--gap", type=float, help="Angle du gap (degrés)")
+    parser.add_argument("--threshold", type=int, help="Seuil du halo d'alerte")
+    parser.add_argument("--max", type=int, help="Valeur maximale de la jauge")
+    parser.add_argument("--ticks", type=str, help="Liste de ticks séparés par des virgules")
+    parser.add_argument("--cursor-offset", type=str, help="Décalage curseur X,Y")
+    parser.add_argument("--debug", action="store_true", help="Afficher la valeur numérique")
+    parser.add_argument("--theme", choices=list(THEMES.keys()), help="Thème de la jauge")
+    parser.add_argument("--provider", choices=["sim", "cv"], default="cv", help="Source des données de Heat")
+    parser.add_argument("--template", type=Path, help="Chemin vers le template d'icône")
+    parser.add_argument("--buffbar", type=str, help="Zone de la barre de buffs (x,y,w,h)")
+    parser.add_argument("--ocrp", type=str, help="Zone OCR relative (ox,oy,w,h)")
+    parser.add_argument("--tesseract", type=Path, help="Chemin de l'exécutable Tesseract")
+    parser.add_argument("--log-level", default="INFO", help="Niveau de log")
+    return parser
+
+
+def configure_logging(level: str) -> None:
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.INFO),
+        format="[%(asctime)s] %(levelname)s %(name)s: %(message)s",
+    )
+
+
+def apply_overrides(config: AppConfig, args: argparse.Namespace) -> None:
+    overlay = config.overlay
+    if args.mode:
+        overlay.mode = args.mode
+    if args.size:
+        overlay.size = args.size
+    if args.ring:
+        overlay.ring_width = args.ring
+    if args.gap:
+        overlay.gap_angle = args.gap
+    if args.threshold:
+        overlay.threshold = args.threshold
+    if args.max:
+        overlay.maximum = args.max
+    if args.ticks:
+        overlay.ticks = tuple(int(x.strip()) for x in args.ticks.split(",") if x.strip())
+    if args.cursor_offset:
+        try:
+            x_str, y_str = args.cursor_offset.split(",")
+            overlay.cursor_offset = (int(x_str), int(y_str))
+        except Exception as exc:
+            raise SystemExit(f"--cursor-offset doit être 'x,y': {exc}") from exc
+    if args.debug:
+        overlay.show_text = True
+    if args.theme:
+        overlay.theme = THEMES[args.theme]
+
+    vision = config.vision
+    if args.template:
+        vision.template_path = args.template
+    if args.buffbar:
+        parts = [p.strip() for p in args.buffbar.split(",") if p.strip()]
+        if len(parts) != 4:
+            raise SystemExit("--buffbar doit contenir 4 valeurs x,y,w,h")
+        vision.buff_bar_region = tuple(int(v) for v in parts)  # type: ignore[assignment]
+    if args.ocrp:
+        parts = [p.strip() for p in args.ocrp.split(",") if p.strip()]
+        if len(parts) != 4:
+            raise SystemExit("--ocrp doit contenir 4 valeurs relatives")
+        vision.ocr_relative_rect = tuple(float(v) for v in parts)  # type: ignore[assignment]
+    if args.tesseract:
+        config.tesseract_cmd = args.tesseract
+
+
+class AppController(QtCore.QObject):
+    """High level controller hooking UI, provider and calibration together."""
+
+    def __init__(self, app: QtWidgets.QApplication, config: AppConfig, provider: HeatProvider, overlay: OverlayWindow) -> None:
+        super().__init__()
+        self._app = app
+        self._config = config
+        self._provider = provider
+        self._overlay = overlay
+        self._wizard = CalibrationWizard(app, config)
+        self._setup_shortcuts()
+
+    def start(self) -> None:
+        self._overlay.start()
+
+    def stop(self) -> None:
+        self._overlay.stop()
+
+    def _setup_shortcuts(self) -> None:
+        shortcuts = {
+            "Ctrl+K": self._run_full_wizard,
+            "Ctrl+I": self._capture_icon,
+            "Ctrl+B": self._capture_buff,
+            "Ctrl+O": self._capture_ocr,
+        }
+        for combo, handler in shortcuts.items():
+            shortcut = QtGui.QShortcut(QtGui.QKeySequence(combo), self._overlay)
+            shortcut.activated.connect(handler)
+
+    def _reload_provider(self) -> None:
+        try:
+            if isinstance(self._provider, VisionHeatProvider):
+                self._provider.stop()
+                new_provider = VisionHeatProvider(self._config)
+                self._provider = new_provider
+                self._overlay.set_provider(new_provider)
+            else:
+                self._provider.start()
+        except Exception:
+            LOGGER.exception("Impossible de redémarrer le provider Vision")
+
+    def _run_full_wizard(self) -> None:
+        LOGGER.info("Ctrl+K: relance du wizard complet")
+        self._overlay.hide()
+        self._provider.stop()
+        try:
+            result = self._wizard.run_full()
+            LOGGER.info("Wizard terminé: %s", result)
+        except Exception:
+            LOGGER.exception("Erreur durant le wizard complet")
+        finally:
+            self._reload_provider()
+            self._overlay.show()
+
+    def _capture_icon(self) -> None:
+        LOGGER.info("Ctrl+I: recalibrage icône")
+        self._overlay.hide()
+        self._provider.stop()
+        try:
+            self._wizard.capture_icon()
+        except Exception:
+            LOGGER.exception("Erreur durant la capture d'icône")
+        finally:
+            self._reload_provider()
+            self._overlay.show()
+
+    def _capture_buff(self) -> None:
+        LOGGER.info("Ctrl+B: recalibrage barre de buffs")
+        self._overlay.hide()
+        self._provider.stop()
+        try:
+            self._wizard.capture_buff_bar()
+        except Exception:
+            LOGGER.exception("Erreur durant la capture de la bande de buffs")
+        finally:
+            self._reload_provider()
+            self._overlay.show()
+
+    def _capture_ocr(self) -> None:
+        LOGGER.info("Ctrl+O: recalibrage zone OCR")
+        self._overlay.hide()
+        self._provider.stop()
+        try:
+            self._wizard.capture_ocr_zone()
+        except Exception:
+            LOGGER.exception("Erreur durant la capture OCR")
+        finally:
+            self._reload_provider()
+            self._overlay.show()
+
+
+def build_provider(config: AppConfig, provider_name: str) -> HeatProvider:
+    if provider_name == "sim":
+        LOGGER.warning("Utilisation du provider simulé - pas de vision réelle")
+        return SimulatedHeatProvider(maximum=config.overlay.maximum)
+    if provider_name == "cv":
+        return VisionHeatProvider(config)
+    raise SystemExit(f"Provider non supporté: {provider_name}")
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    configure_logging(args.log_level)
+    config = AppConfig.load(args.config)
+    apply_overrides(config, args)
+    config.save(args.config)
+
+    qt_args = sys.argv if argv is None else [sys.argv[0], *argv]
+    app = QtWidgets.QApplication(qt_args)
+
+    try:
+        provider = build_provider(config, args.provider)
+    except Exception as exc:
+        LOGGER.error("Impossible d'initialiser le provider %s: %s", args.provider, exc)
+        return 1
+
+    overlay = OverlayWindow(config, provider)
+    controller = AppController(app, config, provider, overlay)
+    controller.start()
+
+    exit_code = app.exec()
+    controller.stop()
+    return exit_code
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/src/heat_overlay/calibration.py
+++ b/src/heat_overlay/calibration.py
@@ -1,0 +1,204 @@
+"""Calibration wizard utilities."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from PySide6 import QtCore, QtGui, QtWidgets
+
+from .config import AppConfig, VisionOptions
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_TEMPLATE_PATH = Path("assets/buff_template_captured.png")
+
+
+class SelectionOverlay(QtWidgets.QWidget):
+    """Full-screen overlay used to capture rectangular selections."""
+
+    selection_made = QtCore.Signal(QtCore.QRect)
+    canceled = QtCore.Signal()
+
+    def __init__(self, pixmap: QtGui.QPixmap, instructions: str, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
+        self._pixmap = pixmap
+        self._instructions = instructions
+        self._start_pos: Optional[QtCore.QPoint] = None
+        self._current_rect: Optional[QtCore.QRect] = None
+        self.setWindowFlag(QtCore.Qt.WindowType.FramelessWindowHint)
+        self.setWindowState(QtCore.Qt.WindowState.WindowFullScreen)
+        self.setCursor(QtCore.Qt.CursorShape.CrossCursor)
+
+    def paintEvent(self, event: QtGui.QPaintEvent) -> None:  # pragma: no cover - GUI heavy
+        painter = QtGui.QPainter(self)
+        painter.drawPixmap(0, 0, self._pixmap)
+        painter.fillRect(self.rect(), QtGui.QColor(0, 0, 0, 80))
+        if self._current_rect:
+            painter.setPen(QtGui.QPen(QtCore.Qt.GlobalColor.yellow, 2))
+            painter.drawRect(self._current_rect)
+        painter.setPen(QtCore.Qt.GlobalColor.white)
+        font = painter.font()
+        font.setPointSize(18)
+        painter.setFont(font)
+        painter.drawText(
+            40,
+            60,
+            self._instructions,
+        )
+
+    def mousePressEvent(self, event: QtGui.QMouseEvent) -> None:  # pragma: no cover - GUI heavy
+        if event.button() == QtCore.Qt.MouseButton.LeftButton:
+            self._start_pos = event.pos()
+            self._current_rect = QtCore.QRect(self._start_pos, QtCore.QSize())
+            self.update()
+        elif event.button() == QtCore.Qt.MouseButton.RightButton:
+            self.canceled.emit()
+            self.close()
+
+    def mouseMoveEvent(self, event: QtGui.QMouseEvent) -> None:  # pragma: no cover - GUI heavy
+        if self._start_pos is None:
+            return
+        self._current_rect = QtCore.QRect(self._start_pos, event.pos()).normalized()
+        self.update()
+
+    def mouseReleaseEvent(self, event: QtGui.QMouseEvent) -> None:  # pragma: no cover - GUI heavy
+        if event.button() == QtCore.Qt.MouseButton.LeftButton and self._current_rect:
+            self.selection_made.emit(self._current_rect.normalized())
+            self.close()
+
+
+@dataclass
+class CalibrationResult:
+    template_path: Path
+    buff_bar_region: QtCore.QRect
+    ocr_relative_rect: tuple[float, float, float, float]
+
+
+class CalibrationWizard(QtCore.QObject):
+    """Interactive calibration wizard."""
+
+    def __init__(self, app: QtWidgets.QApplication, config: AppConfig) -> None:
+        super().__init__()
+        self._app = app
+        self._config = config
+        self._screen = QtWidgets.QApplication.primaryScreen()
+        if self._screen is None:
+            raise RuntimeError("No primary screen detected for calibration")
+
+    def run_full(self) -> Optional[CalibrationResult]:
+        LOGGER.info("Starting full calibration wizard")
+        screenshot = self._screen.grabWindow(0)
+        icon_rect = self._run_selection(screenshot, "Sélectionnez l'icône Rapid Shot (clic gauche, clic droit pour annuler)")
+        if icon_rect is None:
+            return None
+        template_path = self._capture_template(screenshot, icon_rect)
+
+        buff_rect = self._run_selection(screenshot, "Sélectionnez la bande des buffs")
+        if buff_rect is None:
+            return None
+
+        ocr_rect = self._run_selection(screenshot, "Sélectionnez la zone du chiffre sous l'icône")
+        if ocr_rect is None:
+            return None
+
+        relative_rect = self._compute_relative_rect(icon_rect, ocr_rect)
+        result = CalibrationResult(
+            template_path=template_path,
+            buff_bar_region=buff_rect,
+            ocr_relative_rect=relative_rect,
+        )
+        self._apply_result(result)
+        return result
+
+    def capture_icon(self) -> Optional[Path]:
+        screenshot = self._screen.grabWindow(0)
+        rect = self._run_selection(screenshot, "Sélectionnez l'icône Rapid Shot")
+        if rect is None:
+            return None
+        template_path = self._capture_template(screenshot, rect)
+        self._config.vision.template_path = template_path
+        self._config.save()
+        return template_path
+
+    def capture_buff_bar(self) -> Optional[QtCore.QRect]:
+        screenshot = self._screen.grabWindow(0)
+        rect = self._run_selection(screenshot, "Sélectionnez la bande des buffs")
+        if rect is None:
+            return None
+        self._config.vision.buff_bar_region = (rect.x(), rect.y(), rect.width(), rect.height())
+        self._config.save()
+        return rect
+
+    def capture_ocr_zone(self) -> Optional[tuple[float, float, float, float]]:
+        if not self._config.vision.template_path:
+            QtWidgets.QMessageBox.warning(None, "Calibration", "Capturez d'abord l'icône Rapid Shot.")
+            return None
+        screenshot = self._screen.grabWindow(0)
+        icon_rect = self._run_selection(screenshot, "Sélectionnez à nouveau l'icône pour référence")
+        if icon_rect is None:
+            return None
+        ocr_rect = self._run_selection(screenshot, "Sélectionnez la zone du chiffre sous l'icône")
+        if ocr_rect is None:
+            return None
+        relative = self._compute_relative_rect(icon_rect, ocr_rect)
+        self._config.vision.ocr_relative_rect = relative
+        self._config.save()
+        return relative
+
+    def _run_selection(self, pixmap: QtGui.QPixmap, message: str) -> Optional[QtCore.QRect]:
+        selection = SelectionOverlay(pixmap, message)
+        loop = QtCore.QEventLoop()
+        result: dict[str, Optional[QtCore.QRect]] = {"rect": None}
+
+        def on_selection(rect: QtCore.QRect) -> None:
+            result["rect"] = rect
+            loop.quit()
+
+        def on_cancel() -> None:
+            result["rect"] = None
+            loop.quit()
+
+        selection.selection_made.connect(on_selection)
+        selection.canceled.connect(on_cancel)
+        selection.show()
+        loop.exec()
+        selection.deleteLater()
+        return result["rect"]
+
+    def _capture_template(self, pixmap: QtGui.QPixmap, rect: QtCore.QRect) -> Path:
+        template_path = self._config.vision.template_path or DEFAULT_TEMPLATE_PATH
+        template_path.parent.mkdir(parents=True, exist_ok=True)
+        crop = pixmap.copy(rect)
+        crop.save(str(template_path), "PNG")
+        self._config.vision.template_path = template_path
+        self._config.save()
+        LOGGER.info("Template saved to %s", template_path)
+        return template_path
+
+    def _compute_relative_rect(self, icon_rect: QtCore.QRect, ocr_rect: QtCore.QRect) -> tuple[float, float, float, float]:
+        if icon_rect.width() == 0 or icon_rect.height() == 0:
+            raise ValueError("Icon rect must have non-zero size")
+        ox_rel = (ocr_rect.x() - icon_rect.x()) / icon_rect.width()
+        oy_rel = (ocr_rect.y() - icon_rect.y()) / icon_rect.height()
+        w_rel = ocr_rect.width() / icon_rect.width()
+        h_rel = ocr_rect.height() / icon_rect.height()
+        relative = (ox_rel, oy_rel, w_rel, h_rel)
+        self._config.vision.ocr_relative_rect = relative
+        self._config.save()
+        LOGGER.info("OCR relative rect computed: %s", relative)
+        return relative
+
+    def _apply_result(self, result: CalibrationResult) -> None:
+        vision = self._config.vision
+        vision.template_path = result.template_path
+        vision.buff_bar_region = (
+            result.buff_bar_region.x(),
+            result.buff_bar_region.y(),
+            result.buff_bar_region.width(),
+            result.buff_bar_region.height(),
+        )
+        vision.ocr_relative_rect = result.ocr_relative_rect
+        self._config.save()
+        LOGGER.info("Calibration complete")

--- a/src/heat_overlay/config.py
+++ b/src/heat_overlay/config.py
@@ -1,0 +1,157 @@
+"""Configuration models and persistence helpers for the heat overlay."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+import json
+
+DEFAULT_CONFIG_PATH = Path("config.json")
+
+
+@dataclass
+class GaugeTheme:
+    """Visual theme used by the gauge overlay."""
+
+    start_color: str = "#ffdd00"
+    end_color: str = "#ff3300"
+    tick_color: str = "#ffffff"
+    halo_color: str = "#ff000088"
+    background_color: str = "#00000000"
+    text_color: str = "#ffffffff"
+
+
+@dataclass
+class OverlayOptions:
+    """General overlay options."""
+
+    mode: str = "center"  # center or cursor
+    size: int = 320
+    ring_width: int = 18
+    gap_angle: float = 40.0
+    show_text: bool = False
+    ticks: Tuple[int, int, int] = (15, 30, 45)
+    threshold: int = 45
+    maximum: int = 60
+    cursor_offset: Tuple[int, int] = (32, 32)
+    theme: GaugeTheme = field(default_factory=GaugeTheme)
+
+
+@dataclass
+class VisionOptions:
+    """Options required by the computer vision pipeline."""
+
+    template_path: Optional[Path] = None
+    buff_bar_region: Optional[Tuple[int, int, int, int]] = None
+    ocr_relative_rect: Optional[Tuple[float, float, float, float]] = None
+    search_margin: int = 16
+    search_scale_steps: int = 3
+    search_scale_factor: float = 0.12
+    match_threshold: float = 0.75
+    ocr_psm: int = 7
+    ocr_threshold: int = 150
+
+
+@dataclass
+class AppConfig:
+    """Top level configuration."""
+
+    overlay: OverlayOptions = field(default_factory=OverlayOptions)
+    vision: VisionOptions = field(default_factory=VisionOptions)
+    template_library: Dict[str, str] = field(default_factory=dict)
+    tesseract_cmd: Optional[Path] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        def _convert(value: Any) -> Any:
+            if isinstance(value, Path):
+                return str(value)
+            if isinstance(value, tuple):
+                return list(value)
+            if hasattr(value, "to_dict"):
+                return value.to_dict()
+            if dataclass_is_instance(value):
+                result = asdict(value)
+                return {
+                    key: _convert(val)
+                    for key, val in result.items()
+                }
+            if isinstance(value, dict):
+                return {key: _convert(val) for key, val in value.items()}
+            return value
+
+        return _convert(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "AppConfig":
+        overlay_data = data.get("overlay", {})
+        theme_data = overlay_data.get("theme", {})
+        overlay = OverlayOptions(
+            mode=overlay_data.get("mode", "center"),
+            size=overlay_data.get("size", 320),
+            ring_width=overlay_data.get("ring_width", 18),
+            gap_angle=overlay_data.get("gap_angle", 40.0),
+            show_text=overlay_data.get("show_text", False),
+            ticks=tuple(overlay_data.get("ticks", (15, 30, 45))),
+            threshold=overlay_data.get("threshold", 45),
+            maximum=overlay_data.get("maximum", 60),
+            cursor_offset=tuple(overlay_data.get("cursor_offset", (32, 32))),
+            theme=GaugeTheme(**theme_data),
+        )
+        vision_data = data.get("vision", {})
+        vision = VisionOptions(
+            template_path=_maybe_path(vision_data.get("template_path")),
+            buff_bar_region=_maybe_tuple(vision_data.get("buff_bar_region")),
+            ocr_relative_rect=_maybe_tuple(vision_data.get("ocr_relative_rect")),
+            search_margin=vision_data.get("search_margin", 16),
+            search_scale_steps=vision_data.get("search_scale_steps", 3),
+            search_scale_factor=vision_data.get("search_scale_factor", 0.12),
+            match_threshold=vision_data.get("match_threshold", 0.75),
+            ocr_psm=vision_data.get("ocr_psm", 7),
+            ocr_threshold=vision_data.get("ocr_threshold", 150),
+        )
+        template_library = {
+            key: val for key, val in data.get("template_library", {}).items()
+        }
+        tesseract_cmd = _maybe_path(data.get("tesseract_cmd"))
+        return cls(
+            overlay=overlay,
+            vision=vision,
+            template_library=template_library,
+            tesseract_cmd=tesseract_cmd,
+        )
+
+    @classmethod
+    def load(cls, path: Path = DEFAULT_CONFIG_PATH) -> "AppConfig":
+        if not path.exists():
+            return cls()
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+        return cls.from_dict(data)
+
+    def save(self, path: Path = DEFAULT_CONFIG_PATH) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as handle:
+            json.dump(self.to_dict(), handle, indent=2)
+
+
+def _maybe_path(value: Optional[str]) -> Optional[Path]:
+    if value:
+        return Path(value)
+    return None
+
+
+def _maybe_tuple(value: Optional[Any]) -> Optional[Tuple[Any, ...]]:
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        return tuple(value)
+    raise TypeError(f"Expected list/tuple, got {type(value)!r}")
+
+
+def dataclass_is_instance(value: Any) -> bool:
+    try:
+        from dataclasses import is_dataclass
+
+        return is_dataclass(value)
+    except Exception:
+        return False

--- a/src/heat_overlay/overlay.py
+++ b/src/heat_overlay/overlay.py
@@ -1,0 +1,176 @@
+"""Overlay window and gauge rendering."""
+from __future__ import annotations
+
+import logging
+import math
+from typing import Optional
+
+from PySide6 import QtCore, QtGui, QtWidgets
+
+from .config import AppConfig, GaugeTheme, OverlayOptions
+from .providers import HeatProvider
+
+LOGGER = logging.getLogger(__name__)
+
+
+class GaugeWidget(QtWidgets.QWidget):
+    """Custom widget rendering the circular gauge."""
+
+    def __init__(self, options: OverlayOptions, parent: Optional[QtWidgets.QWidget] = None) -> None:
+        super().__init__(parent)
+        self._options = options
+        self._value = 0
+        self._maximum = max(options.maximum, 1)
+        self.setAttribute(QtCore.Qt.WidgetAttribute.WA_TranslucentBackground)
+        self.setFixedSize(options.size, options.size)
+
+    def set_value(self, value: int) -> None:
+        value = max(0, min(self._maximum, value))
+        if value != self._value:
+            self._value = value
+            self.update()
+
+    def set_maximum(self, maximum: int) -> None:
+        self._maximum = max(1, maximum)
+        self.update()
+
+    def paintEvent(self, event: QtGui.QPaintEvent) -> None:  # pragma: no cover - GUI
+        painter = QtGui.QPainter(self)
+        painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing)
+        size = min(self.width(), self.height())
+        margin = self._options.ring_width // 2 + 4
+        rect = QtCore.QRectF(margin, margin, size - 2 * margin, size - 2 * margin)
+
+        start_angle = 90 + self._options.gap_angle / 2
+        span_angle = 360 - self._options.gap_angle
+        progress = min(1.0, self._value / float(self._maximum))
+        span_progress = span_angle * progress
+
+        pen = QtGui.QPen(QtGui.QColor(self._options.theme.background_color))
+        pen.setWidth(self._options.ring_width)
+        painter.setPen(pen)
+        painter.drawArc(rect, int(start_angle * 16), int(-span_angle * 16))
+
+        gradient = QtGui.QConicalGradient(rect.center(), start_angle - span_progress)
+        gradient.setColorAt(0.0, QtGui.QColor(self._options.theme.end_color))
+        gradient.setColorAt(1.0, QtGui.QColor(self._options.theme.start_color))
+        pen.setColor(QtGui.QColor(self._options.theme.start_color))
+        pen.setBrush(gradient)
+        painter.setPen(pen)
+        painter.drawArc(rect, int(start_angle * 16), int(-span_progress * 16))
+
+        painter.setPen(QtGui.QPen(QtGui.QColor(self._options.theme.tick_color), 2))
+        for tick_value in self._options.ticks:
+            angle_ratio = min(1.0, max(0.0, tick_value / float(self._maximum)))
+            tick_angle = start_angle - span_angle * angle_ratio
+            painter.drawLine(
+                self._point_on_circle(rect.center(), rect.width() / 2, tick_angle),
+                self._point_on_circle(rect.center(), rect.width() / 2 - self._options.ring_width, tick_angle),
+            )
+
+        if self._value >= self._options.threshold:
+            halo = QtGui.QColor(self._options.theme.halo_color)
+            halo_pen = QtGui.QPen(halo)
+            halo_pen.setWidth(self._options.ring_width + 6)
+            painter.setPen(halo_pen)
+            painter.drawArc(rect.adjusted(-6, -6, 6, 6), int(start_angle * 16), int(-span_progress * 16))
+
+        if self._options.show_text:
+            painter.setPen(QtGui.QColor(self._options.theme.text_color))
+            font = painter.font()
+            font.setPointSize(max(10, self.width() // 10))
+            font.setBold(True)
+            painter.setFont(font)
+            painter.drawText(self.rect(), QtCore.Qt.AlignmentFlag.AlignCenter, str(self._value))
+
+    @staticmethod
+    def _point_on_circle(center: QtCore.QPointF, radius: float, angle_degrees: float) -> QtCore.QPointF:
+        rad = angle_degrees * 3.14159265 / 180.0
+        return QtCore.QPointF(
+            center.x() + radius * math.cos(rad),
+            center.y() - radius * math.sin(rad),
+        )
+
+
+class OverlayWindow(QtWidgets.QWidget):
+    """Main overlay window that is transparent and click-through."""
+
+    heat_updated = QtCore.Signal(int)
+
+    def __init__(self, config: AppConfig, provider: HeatProvider) -> None:
+        super().__init__(None, QtCore.Qt.WindowType.FramelessWindowHint | QtCore.Qt.WindowType.WindowStaysOnTopHint)
+        self._config = config
+        self._provider = provider
+        self._options = config.overlay
+        self._gauge = GaugeWidget(self._options)
+        self._timer = QtCore.QTimer(self)
+        self._timer.setInterval(50)
+        self._timer.timeout.connect(self._update_heat)
+        layout = QtWidgets.QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._gauge, alignment=QtCore.Qt.AlignmentFlag.AlignCenter)
+        self.setLayout(layout)
+        self.setAttribute(QtCore.Qt.WidgetAttribute.WA_TranslucentBackground)
+        self.setAttribute(QtCore.Qt.WidgetAttribute.WA_TransparentForMouseEvents)
+        self.setWindowFlag(QtCore.Qt.WindowType.Tool)
+        self.setWindowFlag(QtCore.Qt.WindowType.WindowDoesNotAcceptFocus)
+        self.setWindowFlag(QtCore.Qt.WindowType.NoDropShadowWindowHint)
+        self.setWindowTitle("Rapid Shot Heat Overlay")
+        self.resize(self._options.size, self._options.size)
+        self._cursor_timer: Optional[QtCore.QTimer] = None
+        self._setup_cursor_tracking()
+        self.heat_updated.connect(self._gauge.set_value)
+
+    def start(self) -> None:
+        self._provider.start()
+        self._timer.start()
+        if self._options.mode == "cursor" and self._cursor_timer:
+            self._cursor_timer.start()
+        self.show()
+        self._reposition()
+
+    def stop(self) -> None:
+        self._timer.stop()
+        self._provider.stop()
+        if self._cursor_timer:
+            self._cursor_timer.stop()
+
+    def set_provider(self, provider: HeatProvider) -> None:
+        if provider is self._provider:
+            return
+        self.stop()
+        self._provider = provider
+        self.start()
+
+    def _setup_cursor_tracking(self) -> None:
+        if self._options.mode == "cursor":
+            self._cursor_timer = QtCore.QTimer(self)
+            self._cursor_timer.setInterval(30)
+            self._cursor_timer.timeout.connect(self._follow_cursor)
+            self._cursor_timer.start()
+        else:
+            self._cursor_timer = None
+
+    def _follow_cursor(self) -> None:
+        cursor_pos = QtGui.QCursor.pos()
+        offset = self._options.cursor_offset
+        new_pos = QtCore.QPoint(cursor_pos.x() + offset[0], cursor_pos.y() + offset[1])
+        self.move(new_pos)
+
+    def _update_heat(self) -> None:
+        value = self._provider.get_heat()
+        if value is not None:
+            self.heat_updated.emit(int(value))
+        if self._options.mode == "center":
+            self._reposition()
+
+    def _reposition(self) -> None:
+        if self._options.mode != "center":
+            return
+        screen = QtWidgets.QApplication.primaryScreen()
+        if not screen:
+            return
+        geometry = screen.availableGeometry()
+        x = geometry.center().x() - self.width() // 2
+        y = geometry.center().y() - self.height() // 2
+        self.move(x, y)

--- a/src/heat_overlay/providers.py
+++ b/src/heat_overlay/providers.py
@@ -1,0 +1,276 @@
+"""Heat provider implementations."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from threading import Event, Thread, Lock
+from time import perf_counter, sleep
+from typing import Callable, Optional
+import logging
+
+from .config import AppConfig
+
+try:
+    import numpy as np
+except Exception:  # pragma: no cover - numpy might be unavailable in docs/tests
+    np = None  # type: ignore
+
+try:  # pragma: no cover - optional runtime dependency
+    import cv2
+except Exception:
+    cv2 = None  # type: ignore
+
+try:  # pragma: no cover - optional runtime dependency
+    import pytesseract
+except Exception:
+    pytesseract = None  # type: ignore
+
+try:  # pragma: no cover - optional runtime dependency
+    import dxcam
+except Exception:
+    dxcam = None  # type: ignore
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class HeatProvider:
+    """Abstract interface used by the overlay."""
+
+    def start(self) -> None:
+        """Start acquisition."""
+
+    def stop(self) -> None:
+        """Stop acquisition."""
+
+    def get_heat(self) -> Optional[int]:  # pragma: no cover - simple passthrough
+        """Return latest heat value."""
+        raise NotImplementedError
+
+
+@dataclass
+class SimulatedHeatProvider(HeatProvider):
+    """Simple provider useful for development and demos."""
+
+    minimum: int = 0
+    maximum: int = 60
+    period: float = 5.0
+
+    def __post_init__(self) -> None:
+        self._start_time = perf_counter()
+
+    def start(self) -> None:  # pragma: no cover - trivial start
+        self._start_time = perf_counter()
+
+    def stop(self) -> None:  # pragma: no cover - trivial stop
+        pass
+
+    def get_heat(self) -> int:
+        elapsed = (perf_counter() - self._start_time) % self.period
+        ratio = elapsed / self.period
+        value = self.minimum + (self.maximum - self.minimum) * abs(1 - 2 * ratio)
+        return int(round(value))
+
+
+class VisionHeatProvider(HeatProvider):
+    """Vision-based provider using template matching and OCR."""
+
+    def __init__(self, config: AppConfig, callback: Optional[Callable[[int], None]] = None) -> None:
+        if dxcam is None or cv2 is None or pytesseract is None:
+            raise RuntimeError(
+                "VisionHeatProvider requires dxcam, cv2 and pytesseract to be installed"
+            )
+        self._config = config
+        self._vision = config.vision
+        self._callback = callback
+        self._camera = dxcam.create(output_color="BGR")
+        self._thread: Optional[Thread] = None
+        self._stop_event = Event()
+        self._heat_lock = Lock()
+        self._heat_value: Optional[int] = None
+        self._last_position: Optional[tuple[int, int, int, int]] = None
+        self._template_cache: Optional["np.ndarray"] = None
+        self._template_mtime: Optional[float] = None
+
+        if config.tesseract_cmd:
+            pytesseract.pytesseract.tesseract_cmd = str(config.tesseract_cmd)
+
+    def start(self) -> None:
+        if self._thread and self._thread.is_alive():
+            return
+        self._stop_event.clear()
+        self._thread = Thread(target=self._loop, name="VisionHeatProvider", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread:
+            self._thread.join(timeout=2)
+            self._thread = None
+        if self._camera:  # pragma: no cover - hardware resource cleanup
+            self._camera.stop()
+
+    def get_heat(self) -> Optional[int]:
+        with self._heat_lock:
+            return self._heat_value
+
+    def _loop(self) -> None:  # pragma: no cover - requires realtime hardware
+        self._camera.start(
+            target_fps=30,
+            video_mode=True,
+            region=self._vision.buff_bar_region,
+        )
+        while not self._stop_event.is_set():
+            frame = self._camera.get_latest_frame()
+            if frame is None:
+                sleep(0.01)
+                continue
+            try:
+                heat = self._process_frame(frame)
+            except Exception:  # pragma: no cover - safety net
+                LOGGER.exception("Failed to process frame")
+                heat = None
+            if heat is not None:
+                with self._heat_lock:
+                    self._heat_value = heat
+                if self._callback:
+                    self._callback(heat)
+            sleep(0.03)
+
+    def _process_frame(self, frame: "np.ndarray") -> Optional[int]:
+        assert cv2 is not None and np is not None and pytesseract is not None
+        template = self._load_template()
+        if template is None:
+            return None
+
+        match_location, match_scale = self._match_template(frame, template)
+        if match_location is None:
+            return None
+        x, y = match_location
+        scale = match_scale or 1.0
+        template_h = int(template.shape[0] * scale)
+        template_w = int(template.shape[1] * scale)
+
+        rel_rect = self._vision.ocr_relative_rect
+        if rel_rect is None:
+            LOGGER.debug("OCR rect not configured")
+            return None
+        ox_rel, oy_rel, w_rel, h_rel = rel_rect
+        ocr_x = int(x + template_w * ox_rel)
+        ocr_y = int(y + template_h * oy_rel)
+        ocr_w = max(1, int(template_w * w_rel))
+        ocr_h = max(1, int(template_h * h_rel))
+        frame_h, frame_w = frame.shape[:2]
+        ocr_x = max(0, min(frame_w - 1, ocr_x))
+        ocr_y = max(0, min(frame_h - 1, ocr_y))
+        if ocr_x + ocr_w > frame_w:
+            ocr_w = frame_w - ocr_x
+        if ocr_y + ocr_h > frame_h:
+            ocr_h = frame_h - ocr_y
+        roi = frame[ocr_y : ocr_y + ocr_h, ocr_x : ocr_x + ocr_w]
+        if roi.size == 0:
+            LOGGER.debug("OCR ROI empty")
+            return None
+
+        gray = cv2.cvtColor(roi, cv2.COLOR_BGR2GRAY)
+        blur = cv2.GaussianBlur(gray, (3, 3), 0)
+        thresh = cv2.adaptiveThreshold(
+            blur,
+            255,
+            cv2.ADAPTIVE_THRESH_MEAN_C,
+            cv2.THRESH_BINARY_INV,
+            11,
+            2,
+        )
+        _, binary = cv2.threshold(thresh, self._vision.ocr_threshold, 255, cv2.THRESH_BINARY)
+        config = f"--psm {self._vision.ocr_psm} -c tessedit_char_whitelist=0123456789"
+        text = pytesseract.image_to_string(binary, config=config)
+        digits = "".join(ch for ch in text if ch.isdigit())
+        if not digits:
+            LOGGER.debug("OCR produced no digits from %r", text)
+            return None
+        try:
+            value = int(digits)
+        except ValueError:
+            LOGGER.debug("Failed to parse OCR digits: %s", digits)
+            return None
+        return value
+
+    def _load_template(self) -> Optional["np.ndarray"]:
+        assert cv2 is not None and np is not None
+        template_path = self._vision.template_path
+        if not template_path or not template_path.exists():
+            LOGGER.warning("Template path missing: %s", template_path)
+            return None
+        try:
+            mtime = template_path.stat().st_mtime
+        except OSError:
+            mtime = None
+        if self._template_cache is not None and mtime and self._template_mtime == mtime:
+            return self._template_cache
+        template = cv2.imread(str(template_path), cv2.IMREAD_COLOR)
+        if template is None:
+            LOGGER.error("Failed to load template from %s", template_path)
+            return None
+        self._template_cache = template
+        self._template_mtime = mtime
+        return template
+
+    def _match_template(
+        self,
+        frame: "np.ndarray",
+        template: "np.ndarray",
+    ) -> tuple[Optional[tuple[int, int]], Optional[float]]:
+        assert cv2 is not None and np is not None
+        if frame.ndim == 3:
+            frame_gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+        else:
+            frame_gray = frame
+        template_gray = cv2.cvtColor(template, cv2.COLOR_BGR2GRAY)
+
+        def _search(area: "np.ndarray", offset: tuple[int, int]) -> Optional[tuple[tuple[int, int], float, float]]:
+            best: Optional[tuple[tuple[int, int], float, float]] = None
+            for step in range(self._vision.search_scale_steps):
+                scale = 1.0 + self._vision.search_scale_factor * (
+                    step - (self._vision.search_scale_steps // 2)
+                )
+                resized = cv2.resize(
+                    template_gray,
+                    None,
+                    fx=scale,
+                    fy=scale,
+                    interpolation=cv2.INTER_CUBIC,
+                )
+                if area.shape[0] < resized.shape[0] or area.shape[1] < resized.shape[1]:
+                    continue
+                res = cv2.matchTemplate(area, resized, cv2.TM_CCOEFF_NORMED)
+                min_val, max_val, min_loc, max_loc = cv2.minMaxLoc(res)
+                if max_val >= self._vision.match_threshold:
+                    loc = (max_loc[0] + offset[0], max_loc[1] + offset[1])
+                    if not best or max_val > best[2]:
+                        best = (loc, scale, max_val)
+            return best
+
+        best_match: Optional[tuple[tuple[int, int], float, float]] = None
+        if self._last_position is not None:
+            lx, ly, lw, lh = self._last_position
+            margin = self._vision.search_margin
+            x0 = max(lx - margin, 0)
+            y0 = max(ly - margin, 0)
+            x1 = min(lx + lw + margin, frame_gray.shape[1])
+            y1 = min(ly + lh + margin, frame_gray.shape[0])
+            area = frame_gray[y0:y1, x0:x1]
+            best_match = _search(area, (x0, y0))
+
+        if best_match is None:
+            best_match = _search(frame_gray, (0, 0))
+
+        if best_match is None:
+            self._last_position = None
+            return None, None
+
+        (x, y), scale, _score = best_match
+        tw = int(template_gray.shape[1] * scale)
+        th = int(template_gray.shape[0] * scale)
+        self._last_position = (x, y, tw, th)
+        return (x, y), scale
+


### PR DESCRIPTION
## Summary
- implement a configurable PySide6 overlay that renders a circular Heat gauge and supports cursor/centered modes
- add computer-vision and simulated heat providers plus a calibration wizard with guided selections
- document usage, calibration and packaging while defining project metadata and ignores

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cabc0a799c832d8869f386248660d8