### PR TITLE
Add Windows packaging script bundling Tesseract

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,19 +75,40 @@ Toutes les informations sont écrites dans `config.json` sous la racine du proje
 - **cv** : utilise `dxcam` pour capturer l'écran DirectX (Windows), OpenCV pour le template matching multi-échelle et Tesseract pour l'OCR. C'est le mode recommandé en jeu.
 - **sim** : fournisseur sinusoïdal utile pour valider l'UI ou enregistrer des démonstrations.
 
-## Packaging en EXE
+## Packaging Windows (EXE + installeur)
 
-1. Téléchargez la version portable de Tesseract et placez-la dans un dossier `tesseract/` à côté de l'exécutable.
-2. Utilisez PyInstaller :
+Le script `packaging/windows/build_installer.py` automatise la création d'un binaire PyInstaller
+et d'un installeur Inno Setup qui embarquent Tesseract en version portable.
 
-   ```bash
-   pyinstaller --name rapid-shot-overlay --noconsole --onefile \
-     --add-data "assets/*;assets" \
-     --collect-submodules heat_overlay \
-     -p src heat_overlay/app.py
+1. Préparez un environnement Python sur Windows et installez les dépendances :
+
+   ```powershell
+   python -m venv .venv
+   .\.venv\Scripts\activate
+   pip install -e .
+   pip install pyinstaller
    ```
 
-3. Copiez le dossier portable de Tesseract et `config.json` à côté du binaire généré.
+2. Lancez le script de packaging :
+
+   ```powershell
+   python packaging\windows\build_installer.py
+   ```
+
+   Le script télécharge automatiquement l'archive portable de Tesseract, copie son contenu dans
+   `dist\rapid-shot-overlay\tesseract` puis génère l'installeur
+   `dist\installer\RapidShotHeatOverlaySetup.exe` (si `iscc.exe` est disponible).
+
+3. Pour personnaliser le processus, plusieurs options sont disponibles :
+
+   - `--skip-installer` : conserve uniquement le dossier PyInstaller + Tesseract.
+   - `--onefile` : génère un exécutable `--onefile` puis crée un dossier bundle contenant Tesseract.
+   - `--tesseract-url <URL>` : utilise une autre archive portable de Tesseract.
+
+L'application détecte automatiquement `tesseract/tesseract.exe` lorsqu'il est situé à côté de
+`rapid-shot-overlay.exe`, que ce soit dans le dossier PyInstaller ou dans le répertoire
+d'installation généré par Inno Setup. Il n'est donc plus nécessaire d'installer Tesseract
+séparément.
 
 ## Dépannage
 

--- a/packaging/windows/build_installer.py
+++ b/packaging/windows/build_installer.py
@@ -1,0 +1,256 @@
+"""Build a Windows installer that bundles Tesseract."""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+from urllib.request import urlopen
+import zipfile
+
+try:  # Python 3.11+
+    import tomllib  # type: ignore[attr-defined]
+except Exception:  # pragma: no cover - fallback for Python < 3.11
+    import tomli as tomllib  # type: ignore
+
+DEFAULT_TESSERACT_URL = (
+    "https://github.com/UB-Mannheim/tesseract/releases/download/"
+    "v5.3.3.20231005/Tesseract-OCR-w64-5.3.3.20231005.zip"
+)
+
+
+def project_root() -> Path:
+    """Return the repository root (two directories up from this file)."""
+
+    return Path(__file__).resolve().parents[2]
+
+
+def load_version(root: Path) -> str:
+    """Extract the project version from pyproject.toml."""
+
+    pyproject = root / "pyproject.toml"
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    project = data.get("project", {})
+    version = project.get("version")
+    if not version:
+        raise RuntimeError("Impossible de récupérer la version depuis pyproject.toml")
+    return str(version)
+
+
+def run_pyinstaller(root: Path, dist_dir: Path, build_dir: Path, *, onefile: bool) -> None:
+    """Invoke PyInstaller to build the application."""
+
+    src_dir = root / "src"
+    assets_dir = root / "assets"
+    if not assets_dir.exists():
+        raise RuntimeError("Le dossier assets/ est introuvable")
+
+    add_data = f"{assets_dir}{os.pathsep}assets"
+    cmd = [
+        sys.executable,
+        "-m",
+        "PyInstaller",
+        "--name",
+        "rapid-shot-overlay",
+        "--noconfirm",
+        "--clean",
+        "--distpath",
+        str(dist_dir),
+        "--workpath",
+        str(build_dir / "pyinstaller"),
+        "--specpath",
+        str(build_dir / "pyinstaller"),
+        "--collect-submodules",
+        "heat_overlay",
+        "--collect-submodules",
+        "cv2",
+        "--collect-submodules",
+        "PySide6",
+        "--hidden-import",
+        "pytesseract",
+        "--hidden-import",
+        "dxcam",
+        "--add-data",
+        add_data,
+        "-p",
+        str(src_dir),
+        str(src_dir / "heat_overlay" / "app.py"),
+    ]
+    if onefile:
+        cmd.append("--onefile")
+    else:
+        cmd.append("--onedir")
+    cmd.append("--noconsole")
+    subprocess.check_call(cmd)
+
+
+def _clean_directory(path: Path) -> None:
+    if path.exists():
+        shutil.rmtree(path)
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def ensure_bundle(dist_dir: Path, *, onefile: bool) -> tuple[Path, Path]:
+    """Return the directory that must be shipped and the executable path."""
+
+    if onefile:
+        exe_path = dist_dir / "rapid-shot-overlay.exe"
+        if not exe_path.exists():
+            raise RuntimeError("Exécutable PyInstaller introuvable (rapid-shot-overlay.exe)")
+        bundle_dir = dist_dir / "rapid-shot-overlay-bundle"
+        if bundle_dir.exists():
+            shutil.rmtree(bundle_dir)
+        bundle_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(exe_path, bundle_dir / exe_path.name)
+        return bundle_dir, bundle_dir / exe_path.name
+    bundle_dir = dist_dir / "rapid-shot-overlay"
+    exe_path = bundle_dir / "rapid-shot-overlay.exe"
+    if not exe_path.exists():
+        raise RuntimeError("Exécutable PyInstaller introuvable dans dist/rapid-shot-overlay/")
+    return bundle_dir, exe_path
+
+
+def download_tesseract(url: str, cache_dir: Path, *, skip_download: bool) -> Path:
+    """Download and extract the portable Tesseract build."""
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    archive_name = Path(url).name
+    archive_path = cache_dir / archive_name
+    if not archive_path.exists():
+        if skip_download:
+            raise RuntimeError(
+                "Archive Tesseract absente du cache et téléchargement désactivé"
+            )
+        print(f"Téléchargement de Tesseract depuis {url} ...")
+        with urlopen(url) as response, archive_path.open("wb") as handle:
+            shutil.copyfileobj(response, handle)
+    extract_dir = cache_dir / "tesseract-portable"
+    if extract_dir.exists():
+        return extract_dir
+    print(f"Extraction de {archive_path} ...")
+    with zipfile.ZipFile(archive_path) as archive:
+        archive.extractall(cache_dir)
+    candidate_dir: Optional[Path] = None
+    for path in cache_dir.iterdir():
+        if path.is_dir() and (path / "tesseract.exe").exists():
+            candidate_dir = path
+            break
+    if candidate_dir is None:
+        raise RuntimeError("Impossible de localiser tesseract.exe dans l'archive téléchargée")
+    if extract_dir.exists():
+        shutil.rmtree(extract_dir)
+    shutil.move(str(candidate_dir), str(extract_dir))
+    return extract_dir
+
+
+def copy_tesseract(portable_dir: Path, bundle_dir: Path) -> Path:
+    """Copy the portable Tesseract folder next to the executable."""
+
+    target = bundle_dir / "tesseract"
+    if target.exists():
+        shutil.rmtree(target)
+    shutil.copytree(portable_dir, target)
+    return target
+
+
+def build_installer(
+    script_path: Path,
+    *,
+    bundle_dir: Path,
+    version: str,
+    output_dir: Path,
+    iscc_executable: str,
+) -> None:
+    """Invoke Inno Setup compiler if available."""
+
+    if sys.platform != "win32":
+        print("Compilation Inno Setup ignorée (plateforme non Windows)")
+        return
+    if shutil.which(iscc_executable) is None:
+        print(f"Inno Setup introuvable sur PATH ({iscc_executable}) -> étape ignorée")
+        return
+    output_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        iscc_executable,
+        f"/DMyAppVersion={version}",
+        f"/DDistDir={bundle_dir}",
+        f"/DOutputDir={output_dir}",
+        str(script_path),
+    ]
+    subprocess.check_call(cmd)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Construit un exécutable PyInstaller et un installeur Windows"
+    )
+    parser.add_argument(
+        "--tesseract-url",
+        default=DEFAULT_TESSERACT_URL,
+        help="URL de l'archive portable de Tesseract",
+    )
+    parser.add_argument(
+        "--skip-download",
+        action="store_true",
+        help="Ne pas télécharger Tesseract (utilise le cache existant)",
+    )
+    parser.add_argument(
+        "--skip-pyinstaller",
+        action="store_true",
+        help="Suppose que dist/ contient déjà la build PyInstaller",
+    )
+    parser.add_argument(
+        "--skip-installer",
+        action="store_true",
+        help="N'exécute pas Inno Setup même s'il est disponible",
+    )
+    parser.add_argument(
+        "--onefile",
+        action="store_true",
+        help="Construit l'exécutable PyInstaller en mode --onefile",
+    )
+    parser.add_argument(
+        "--iscc",
+        default="iscc",
+        help="Chemin vers l'exécutable Inno Setup Compiler",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    root = project_root()
+    dist_dir = root / "dist"
+    build_dir = root / "build"
+    build_dir.mkdir(parents=True, exist_ok=True)
+    if not args.skip_pyinstaller:
+        _clean_directory(dist_dir)
+        run_pyinstaller(root, dist_dir, build_dir, onefile=args.onefile)
+    bundle_dir, exe_path = ensure_bundle(dist_dir, onefile=args.onefile)
+    print(f"Exécutable PyInstaller: {exe_path}")
+    tesseract_dir = download_tesseract(
+        args.tesseract_url, build_dir / "tesseract", skip_download=args.skip_download
+    )
+    copied_dir = copy_tesseract(tesseract_dir, bundle_dir)
+    print(f"Tesseract copié dans: {copied_dir}")
+    version = load_version(root)
+    print(f"Version détectée: {version}")
+    if args.skip_installer:
+        print("Étape Inno Setup explicitement ignorée")
+        return
+    script_path = root / "packaging" / "windows" / "rapid-shot-overlay.iss"
+    output_dir = dist_dir / "installer"
+    build_installer(
+        script_path,
+        bundle_dir=bundle_dir,
+        version=version,
+        output_dir=output_dir,
+        iscc_executable=args.iscc,
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    main()

--- a/packaging/windows/rapid-shot-overlay.iss
+++ b/packaging/windows/rapid-shot-overlay.iss
@@ -1,0 +1,57 @@
+; Inno Setup script for Rapid Shot Heat Overlay
+
+#ifndef MyAppName
+#define MyAppName "Rapid Shot Heat Overlay"
+#endif
+
+#ifndef MyAppVersion
+#define MyAppVersion "0.1.0"
+#endif
+
+#ifndef MyAppPublisher
+#define MyAppPublisher "AIM"
+#endif
+
+#ifndef MyAppExeName
+#define MyAppExeName "rapid-shot-overlay.exe"
+#endif
+
+#ifndef DistDir
+#define DistDir "..\\..\\dist\\rapid-shot-overlay"
+#endif
+
+#ifndef OutputDir
+#define OutputDir "..\\..\\dist\\installer"
+#endif
+
+[Setup]
+AppId={{1F6F1C05-CCCB-4ED9-89DD-1E6FD7748C8D}}
+AppName={#MyAppName}
+AppVersion={#MyAppVersion}
+AppPublisher={#MyAppPublisher}
+DefaultDirName={autopf}\Rapid Shot Heat Overlay
+DisableProgramGroupPage=yes
+OutputDir={#OutputDir}
+OutputBaseFilename=RapidShotHeatOverlaySetup
+Compression=lzma
+SolidCompression=yes
+WizardStyle=modern
+PrivilegesRequired=lowest
+ArchitecturesInstallIn64BitMode=x64
+
+[Languages]
+Name: "french"; MessagesFile: "compiler:Languages\French.isl"
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"
+
+[Files]
+Source: "{#DistDir}\\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs ignoreversion
+
+[Icons]
+Name: "{autoprograms}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\{#MyAppExeName}"; Description: "{cm:LaunchProgram,{#MyAppName}}"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
## Summary
- automatically detect a bundled Tesseract executable at runtime so the overlay works without a separate install
- add a Windows packaging script that builds the PyInstaller bundle, downloads portable Tesseract, and optionally runs Inno Setup
- document the packaging flow and provide an Inno Setup script for producing a full installer

## Testing
- python -m compileall src packaging

------
https://chatgpt.com/codex/tasks/task_e_68cbc6d4c904832dbd003353472b874c