### PR TITLE
Add Vulkan-compatible capture backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Outil autonome destiné à suivre en temps réel la Heat du sort **Rapid Shot** 
 - **Vision par ordinateur** : localisation multi-échelle du buff Rapid Shot et lecture fiable du compteur de Heat via Tesseract.
 - **Modes d'affichage** : jauge centrée ou attachée au curseur avec offset configurable.
 - **Personnalisation complète** : taille, largeur d'anneau, gap, couleurs (thèmes), ticks fixes, halo visuel et affichage numérique optionnel.
+- **Compatibilité DirectX & Vulkan** : capture écran possible via `dxcam` ou `mss` (Windows Graphics Capture), sélection automatique du backend le plus adapté.
 - **Assistant de calibration** : sélection guidée de l'icône, de la barre de buffs et de la zone OCR. Relance possible via raccourcis (Ctrl+K/I/B/O).
 - **Sauvegarde automatique** : les paramètres sont stockés dans `config.json` (chemins de template, zone de capture, offsets OCR, etc.).
 - **Mode simulation** : un fournisseur interne permet de tester l'interface sans lancer le jeu.
@@ -50,6 +51,7 @@ heat-overlay --provider sim --mode cursor --debug
 | `--buffbar x,y,w,h` | Définit la région de capture de la barre de buffs. |
 | `--ocrp ox,oy,w,h` | Définit la zone OCR relative à l'icône. |
 | `--tesseract PATH` | Chemin vers `tesseract.exe` portable. |
+| `--capture-backend {auto,dxcam,mss}` | Forcer un backend de capture (`mss` recommandé pour Vulkan plein écran). |
 | `--provider {cv,sim}` | Sélectionne le fournisseur de Heat. |
 | `--config PATH` | Fichier de configuration personnalisé. |
 | `--log-level` | Niveau de log (`INFO`, `DEBUG`, ...). |
@@ -72,7 +74,7 @@ Toutes les informations sont écrites dans `config.json` sous la racine du proje
 
 ## Fournisseur de Heat
 
-- **cv** : utilise `dxcam` pour capturer l'écran DirectX (Windows), OpenCV pour le template matching multi-échelle et Tesseract pour l'OCR. C'est le mode recommandé en jeu.
+- **cv** : utilise `dxcam` ou `mss` (Windows Graphics Capture) pour capturer l'écran quelle que soit l'API graphique (DirectX, Vulkan), OpenCV pour le template matching multi-échelle et Tesseract pour l'OCR. Le backend est sélectionné automatiquement mais peut être forcé via `--capture-backend`.
 - **sim** : fournisseur sinusoïdal utile pour valider l'UI ou enregistrer des démonstrations.
 
 ## Packaging en EXE

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
   "dxcam>=0.0.4",
   "pytesseract>=0.3.10",
   "numpy>=1.24",
+  "mss>=9.0",
 ]
 
 [project.scripts]

--- a/src/heat_overlay/app.py
+++ b/src/heat_overlay/app.py
@@ -55,6 +55,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--buffbar", type=str, help="Zone de la barre de buffs (x,y,w,h)")
     parser.add_argument("--ocrp", type=str, help="Zone OCR relative (ox,oy,w,h)")
     parser.add_argument("--tesseract", type=Path, help="Chemin de l'exécutable Tesseract")
+    parser.add_argument(
+        "--capture-backend",
+        choices=["auto", "dxcam", "mss"],
+        help="Force un backend de capture (auto, dxcam ou mss compatible Vulkan)",
+    )
     parser.add_argument("--log-level", default="INFO", help="Niveau de log")
     return parser
 
@@ -108,6 +113,8 @@ def apply_overrides(config: AppConfig, args: argparse.Namespace) -> None:
         vision.ocr_relative_rect = tuple(float(v) for v in parts)  # type: ignore[assignment]
     if args.tesseract:
         config.tesseract_cmd = args.tesseract
+    if args.capture_backend:
+        vision.capture_backend = args.capture_backend
 
 
 class AppController(QtCore.QObject):

--- a/src/heat_overlay/config.py
+++ b/src/heat_overlay/config.py
@@ -44,6 +44,7 @@ class VisionOptions:
     template_path: Optional[Path] = None
     buff_bar_region: Optional[Tuple[int, int, int, int]] = None
     ocr_relative_rect: Optional[Tuple[float, float, float, float]] = None
+    capture_backend: str = "auto"
     search_margin: int = 16
     search_scale_steps: int = 3
     search_scale_factor: float = 0.12
@@ -102,6 +103,7 @@ class AppConfig:
             template_path=_maybe_path(vision_data.get("template_path")),
             buff_bar_region=_maybe_tuple(vision_data.get("buff_bar_region")),
             ocr_relative_rect=_maybe_tuple(vision_data.get("ocr_relative_rect")),
+            capture_backend=vision_data.get("capture_backend", "auto"),
             search_margin=vision_data.get("search_margin", 16),
             search_scale_steps=vision_data.get("search_scale_steps", 3),
             search_scale_factor=vision_data.get("search_scale_factor", 0.12),


### PR DESCRIPTION
## Summary
- add a generic screen-capture abstraction with MSS fallback so the vision provider works with Vulkan as well as DirectX
- expose the capture backend through configuration/CLI and document the new option
- include MSS in the project dependencies so the packaged app can use the new backend

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cbcb93c100832d99e94d8f730712d2