### PR TITLE
Add Vulkan-compatible capture backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ heat-overlay --provider sim --mode cursor --debug
 | `--ocrp ox,oy,w,h` | Définit la zone OCR relative à l'icône. |
 | `--tesseract PATH` | Chemin vers `tesseract.exe` portable. |
 | `--provider {cv,sim}` | Sélectionne le fournisseur de Heat. |
+| `--capture-backend {auto,dxcam,mss,vulkan}` | Choisit le backend de capture (`auto` tente DirectX puis Vulkan). |
 | `--config PATH` | Fichier de configuration personnalisé. |
 | `--log-level` | Niveau de log (`INFO`, `DEBUG`, ...). |
 
@@ -72,7 +73,7 @@ Toutes les informations sont écrites dans `config.json` sous la racine du proje
 
 ## Fournisseur de Heat
 
-- **cv** : utilise `dxcam` pour capturer l'écran DirectX (Windows), OpenCV pour le template matching multi-échelle et Tesseract pour l'OCR. C'est le mode recommandé en jeu.
+- **cv** : capture via `dxcam` (DirectX) ou `mss` (capture générique compatible Vulkan) suivant le backend sélectionné (`--capture-backend` ou `vision.capture_backend` dans la config), puis applique OpenCV pour le template matching multi-échelle et Tesseract pour l'OCR. C'est le mode recommandé en jeu.
 - **sim** : fournisseur sinusoïdal utile pour valider l'UI ou enregistrer des démonstrations.
 
 ## Packaging Windows (EXE + installeur)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
   "PySide6>=6.6",
   "opencv-python>=4.8",
   "dxcam>=0.0.4",
+  "mss>=9.0",
   "pytesseract>=0.3.10",
   "numpy>=1.24",
 ]

--- a/src/heat_overlay/app.py
+++ b/src/heat_overlay/app.py
@@ -51,6 +51,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--debug", action="store_true", help="Afficher la valeur numérique")
     parser.add_argument("--theme", choices=list(THEMES.keys()), help="Thème de la jauge")
     parser.add_argument("--provider", choices=["sim", "cv"], default="cv", help="Source des données de Heat")
+    parser.add_argument(
+        "--capture-backend",
+        choices=["auto", "dxcam", "mss", "vulkan"],
+        help="Backend de capture pour la vision",
+    )
     parser.add_argument("--template", type=Path, help="Chemin vers le template d'icône")
     parser.add_argument("--buffbar", type=str, help="Zone de la barre de buffs (x,y,w,h)")
     parser.add_argument("--ocrp", type=str, help="Zone OCR relative (ox,oy,w,h)")
@@ -100,6 +105,11 @@ def apply_overrides(config: AppConfig, args: argparse.Namespace) -> None:
     vision = config.vision
     if args.template:
         vision.template_path = args.template
+    if args.capture_backend:
+        backend = args.capture_backend.lower()
+        if backend == "vulkan":
+            backend = "mss"
+        vision.capture_backend = backend
     if args.buffbar:
         parts = [p.strip() for p in args.buffbar.split(",") if p.strip()]
         if len(parts) != 4:

--- a/src/heat_overlay/config.py
+++ b/src/heat_overlay/config.py
@@ -50,6 +50,7 @@ class VisionOptions:
     match_threshold: float = 0.75
     ocr_psm: int = 7
     ocr_threshold: int = 150
+    capture_backend: str = "auto"
 
 
 @dataclass
@@ -108,6 +109,7 @@ class AppConfig:
             match_threshold=vision_data.get("match_threshold", 0.75),
             ocr_psm=vision_data.get("ocr_psm", 7),
             ocr_threshold=vision_data.get("ocr_threshold", 150),
+            capture_backend=vision_data.get("capture_backend", "auto"),
         )
         template_library = {
             key: val for key, val in data.get("template_library", {}).items()


### PR DESCRIPTION
## Summary
- add an MSS-based capture backend and auto-selection logic so the vision provider works with both DirectX and Vulkan
- expose the capture backend through configuration/CLI overrides and document the new option
- include the MSS dependency required for the Vulkan-compatible backend

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cbce86e7b8832db19ef2223ecf39da